### PR TITLE
Fix UnitTest results unavailability when changing namespace

### DIFF
--- a/ci/Orchestrator.cls
+++ b/ci/Orchestrator.cls
@@ -68,9 +68,9 @@ ClassMethod CompileRuntime() As %Status [ Private ]
 
 ClassMethod RunInstallerSetup(ByRef vars  As %String = "") As %Status [ Private ]
 {
-    write !, "Orchestrator: Running the installer setup.", !!
-    $$$QuitOnError(##class(App.Installer).setup(.vars))
-    return $$$OK
+  write !, "Orchestrator: Running the installer setup.", !!
+  $$$QuitOnError(##class(App.Installer).setup(.vars))
+  return $$$OK
 }
 
 ClassMethod GetEnvironmentVars(Output vars As %String = "", Output envs As %ArrayOfDataTypes = "") As %Status [ Private ]

--- a/ci/Runner.cls
+++ b/ci/Runner.cls
@@ -10,25 +10,37 @@ ClassMethod Run(configuration As CI.Configuration) As %Status
   set environmentNS = configuration.GetEnv("CI_NAMESPACE")
   set $namespace = $get(environmentNS, $namespace)
 
-  do configuration.GetTestParameters(.params)
+  do ..ResolveConfiguration(configuration, .testSpecs, .flags, .params)
+  do ..DescribeConfiguration(testSpecs, flags)
 
-  #define NULL $s($$$isWINDOWS : "//./nul", 1: "/dev/null")
+  return ..RunSilently(testSpecs, flags, .params)
+}
+
+ClassMethod ResolveConfiguration(configuration As CI.Configuration, Output testSpecs As %String, Output flags As %String, Output params As %String)
+{
+  do configuration.GetTestParameters(.params)
 
   set ^UnitTestRoot = "/opt/ci/app"
   set flags = "/"_configuration.RecurseFlag_"/run/noload/nodelete/nodisplay"
-  set testSpec = configuration.TestSuite_":"_configuration.TestCase
+  set testSpecs = configuration.TestSuite_":"_configuration.TestCase
+}
 
+ClassMethod DescribeConfiguration(testSpecs As %String, flags As %String) [ Private ]
+{
   write "Runner: Running test suites from: "_^UnitTestRoot_"."
   write !, "Runner: Flags: "_flags
-  write !, "Runner: Spec: "_$select(testSpec = ":" : "none", 1: testSpec)
+  write !, "Runner: Spec: "_$select(testSpecs = ":" : "none", 1: testSpecs)
   write !, "Runner: Notice: The test execution summary will be displayed at the end."
+}
 
+ClassMethod RunSilently(testSpecs As %String, flags As %String, ByRef params As %String) As %Status [ Private ]
+{
   set io = $io
 
   open $$$NULL
   use $$$NULL
 
-  set sc = ##class(%UnitTest.Manager).RunTest(testSpec, flags, .params)
+  set sc = ##class(%UnitTest.Manager).RunTest(testSpecs, flags, .params)
 
   use io
   close $$$NULL
@@ -38,13 +50,15 @@ ClassMethod Run(configuration As CI.Configuration) As %Status
 
 ClassMethod OnAfterRun(configuration As CI.Configuration) As %Status
 {
-  return ..HandleUnitTestFeedback()
+  return ..HandleUnitTestFeedback(configuration)
 }
 
-ClassMethod HasAnyTestBeenExecuted() As %Boolean
+ClassMethod HasAnyTestBeenExecuted() As %Boolean [ Private ]
 {
-  &sql(SELECT COUNT (ID) INTO :total FROM %UNITTEST_RESULT.TESTASSERT)
-  if total = 0 {
+  set found = 0
+  &sql(SELECT TOP 1 ID INTO :found FROM %UNITTEST_RESULT.TESTASSERT)
+
+  if found = 0 {
     write $$$BOLDYELLOW("No tests suites were found. The runner has been aborted."), !
     return 0
   }
@@ -52,8 +66,13 @@ ClassMethod HasAnyTestBeenExecuted() As %Boolean
   return 1
 }
 
-ClassMethod HandleUnitTestFeedback() As %Status [ Private ]
+ClassMethod HandleUnitTestFeedback(configuration As CI.Configuration) As %Status [ Private ]
 {
+  new $namespace
+
+  set environmentNS = configuration.GetEnv("CI_NAMESPACE")
+  set $namespace = $get(environmentNS, $namespace)
+
   if '..HasAnyTestBeenExecuted() return $$$OK
   do ..GetAssertionResult(.failure, .success)
 

--- a/ci/ci.inc
+++ b/ci/ci.inc
@@ -4,3 +4,4 @@
 #define BOLDGREEN(%msg) $$$ESCKEY_$zcvt("[32;1m"_%msg_$$$ESCKEY_"[0m", "O", "UTF8")
 #define BOLDRED(%msg) $$$ESCKEY_$zcvt("[31;1m"_%msg_$$$ESCKEY_"[0m", "O", "UTF8")
 #define BOLDYELLOW(%msg) $$$ESCKEY_$zcvt("[33;1m"_%msg_$$$ESCKEY_"[0m", "O", "UTF8")
+#define NULL $s($$$isWINDOWS : "//./nul", 1: "/dev/null")


### PR DESCRIPTION
### FIXES

* Fixed an issue where when the `CI_NAMESPACE` was provided, the UnitTest results were not available due to the methods Run and OnAfterRun being executed in different circustances, thus resetting the namespace to the default.

### CHORE

* Improved Runner class legibility.